### PR TITLE
Fix installing ng2-dracula in a project without typings.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,8 +35,7 @@
     "ci": "npm run e2e && npm run test",
     "docs": "./node_modules/.bin/typedoc --options typedoc.json src/app/directives/dragula.directive.ts",
     "start": "npm run server",
-    "postinstall": "./node_modules/.bin/typings install",
-    "prepublish": "./node_modules/.bin/tsc",
+    "prepublish": "./node_modules/.bin/typings install && ./node_modules/.bin/tsc",
     "postversion": "git push origin master && git push --tags"
   },
   "dependencies": {


### PR DESCRIPTION
Installing ng2-dracula in a fresh new project without typings.json failed:

	npm init
	npm install ng2-dragula --save-dev

	> ng2-dragula@1.1.9 postinstall ***********\test\node_modules\ng2-dragula
	> typings install

	typings ERR! message Unable to resolve Typings dependencies
	typings ERR! caused by Unable to find "typings.json" from "***********\test\node_modules\ng2-dragula"

	typings ERR! cwd ***********\test\node_modules\ng2-dragula
	typings ERR! system Windows_NT 6.1.7601
	typings ERR! command "C:\\Program Files\\nodejs\\node.exe" "C:\\Users\\Me\\AppData\\Roaming\\npm\\node_modules\\typings\\dist\\bin.js" "install"
	typings ERR! node -v v4.4.1
	typings ERR! typings -v 0.8.1

	typings ERR! If you need help, you may report this error at:
	typings ERR!   <https://github.com/typings/typings/issues>
	npm WARN ng2-dragula@1.1.9 requires a peer of @angular/common@^2.0.0-rc.1 but none was installed.
	npm WARN ng2-dragula@1.1.9 requires a peer of @angular/core@^2.0.0-rc.1 but none was installed.
	npm WARN test@1.0.0 No description
	npm WARN test@1.0.0 No repository field.
	npm ERR! Windows_NT 6.1.7601
	npm ERR! argv "C:\\Program Files\\nodejs\\node.exe" "C:\\Users\\Me\\AppData\\Roaming\\npm\\node_modules\\npm\\bin\\npm-cli.js" "install" "ng2-dragula" "--save-dev"
	npm ERR! node v4.4.1
	npm ERR! npm  v3.8.9
