### PR TITLE
chore(package): add typings parameter to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "ng2-dragula",
   "version": "1.2.1",
   "main": "ng2-dragula.js",
+  "typings": "ng2-dragula.d.ts",
   "description": "Simple drag and drop with dragula",
   "repository": {
     "type": "git",


### PR DESCRIPTION
My TypeScript would not compile by just importing `'ng2-dragula'` without this typings parameter.