### PR TITLE
Wip/dragula options input binding

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,19 @@ class ConfigExample {
 }
 ```
 
+You can also set your options by binding an options object to the `dragulaOptions` attribute.
+
+```js
+options: any = {
+  removeOnSpill: true
+}
+```
+
+```html
+<div [dragula]='"bag-one"' [dragulaOptions]="options"></div>
+<div [dragula]='"bag-two"' [dragulaOptions]="options"></div>
+```
+
 ## Events
 
 Whenever a `drake` instance is created with the `dragula` directive, there are several events you can subscribe to via `DragulaService`. Each event emits an `Array` where the first item is the name of the bag. The remaining items depend on the event. The sample below illustrates how you can use destructuring to assign the values from the event. Refer to: https://github.com/bevacqua/dragula#drakeon-events

--- a/components/dragula.class.ts
+++ b/components/dragula.class.ts
@@ -1,2 +1,2 @@
 import * as dragulaExpt from 'dragula';
-export const dragula: (value?: any) => any = (dragulaExpt as any).default || dragulaExpt;
+export const dragula: (containers?: any, options?: any) => any = (dragulaExpt as any).default || dragulaExpt;

--- a/components/dragula.directive.ts
+++ b/components/dragula.directive.ts
@@ -8,6 +8,7 @@ import { dragula } from './dragula.class';
 export class DragulaDirective implements OnInit, OnChanges {
   @Input('dragula') public bag: string;
   @Input() public dragulaModel: any;
+  @Input() public dragulaOptions: any;
   private container: any;
   private drake: any;
 
@@ -32,9 +33,7 @@ export class DragulaDirective implements OnInit, OnChanges {
       checkModel();
       this.drake.containers.push(this.container);
     } else {
-      this.drake = dragula({
-        containers: [this.container]
-      });
+      this.drake = dragula([this.container], Object.assign({}, this.dragulaOptions));
       checkModel();
       this.dragulaService.add(this.bag, this.drake);
     }


### PR DESCRIPTION
Our team had a need to assign drake options via an attribute binding, similar to what was brought up in #317, and this has been working well.

Added an additional @Input binding to apply options if they are given, and changed the dragula constructor used to allow passing through the options object.  Dragula did not play well with a common object reference, thus the Object.assign - i'm not sure if we would need a deep clone here or not for more complex options?
