### PR TITLE
Update Readme.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,8 +94,8 @@ There's a `dragula` directive that allows you to group containers together. That
 If your `ngFor` is compiled from array, you may wish to have it synced. For that purpose you need to provide model by setting the `dragulaModel` attribute on the bag element.
 
 ```html
-<ul>
-  <li *ngFor="let item of items" [dragula]='"bag-one"' [dragulaModel]='items'></li>
+<ul [dragula]='"bag-one"' [dragulaModel]='items'>
+  <li *ngFor="let item of items"></li>
 </ul>
 ```
 


### PR DESCRIPTION
When using dragularModel, the dragula and dragulaModel have to be placed in the parent container (not the children), or the children disappear on drop.
Documentation issue, mentionned in #82 and #445.