### PR TITLE
Remove dragula from installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Try out the [demo](http://valor-software.github.io/ng2-dragula/index.html)!
 You can get it on npm.
 
 ```shell
-npm install ng2-dragula dragula --save
+npm install ng2-dragula --save
 ```
 
 # Setup


### PR DESCRIPTION
Remove unnecessary installing dragula package from installation instructions in readme, it's already list in package dependenices