### PR TITLE
Relax peer dependencies to support angular 4.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,9 @@
   },
   "peerDependencies": {
     "@angular/core": "^2.3.1 || >=4.0.0",
-    "@angular/common": "^2.3.1 || >=4.0.0"
+    "@angular/common": "^2.3.1 || >=4.0.0",
+    "@angular/compiler": "^2.3.1 || >=4.0.0",
+    "@angular/forms": "^2.3.1 || >=4.0.0"
   },
   "devDependencies": {
     "@angular/common": "2.4.3",


### PR DESCRIPTION
Fix #636 

Not sure if this is the best way to resolve it, but works fine for me.