### PR TITLE
Added Dragula's event handlers as Outputs

### DIFF
--- a/src/components/dragula.directive.ts
+++ b/src/components/dragula.directive.ts
@@ -10,7 +10,7 @@ export class DragulaDirective implements OnInit, OnChanges {
 
   @Output() public dragulaOnDrop: EventEmitter<any> = new EventEmitter<any>();
   @Output() public dragulaOnDrag: EventEmitter<any> = new EventEmitter<any>();
-  @Output() public dragulaOnDragend: EventEmitter<any> = new EventEmitter<any>();
+  @Output() public dragulaOnDragEnd: EventEmitter<any> = new EventEmitter<any>();
   @Output() public dragulaOnCancel: EventEmitter<any> = new EventEmitter<any>();
   @Output() public dragulaOnRemove: EventEmitter<any> = new EventEmitter<any>();
   @Output() public dragulaOnShadow: EventEmitter<any> = new EventEmitter<any>();
@@ -57,7 +57,7 @@ export class DragulaDirective implements OnInit, OnChanges {
         this.dragulaOnDrag.emit(args);
       });
       this.drake.on('dragend', (...args: any[]): void => {
-        this.dragulaOnDragend.emit(args);
+        this.dragulaOnDragEnd.emit(args);
       });
       this.drake.on('cancel', (...args: any[]): void => {
         this.dragulaOnCancel.emit(args);

--- a/src/components/dragula.directive.ts
+++ b/src/components/dragula.directive.ts
@@ -1,17 +1,29 @@
-import { Directive, Input, ElementRef, OnInit, OnChanges, SimpleChange } from '@angular/core';
+import { Directive, Input, Output, ElementRef, OnInit, OnChanges, EventEmitter, SimpleChange } from '@angular/core';
 import { DragulaService } from './dragula.provider';
 import { dragula } from './dragula.class';
 
-@Directive({selector: '[dragula]'})
+@Directive({ selector: '[dragula]' })
 export class DragulaDirective implements OnInit, OnChanges {
   @Input() public dragula: string;
   @Input() public dragulaModel: any;
   @Input() public dragulaOptions: any;
+
+  @Output() public dragulaOnDrop: EventEmitter<any> = new EventEmitter<any>();
+  @Output() public dragulaOnDrag: EventEmitter<any> = new EventEmitter<any>();
+  @Output() public dragulaOnDragend: EventEmitter<any> = new EventEmitter<any>();
+  @Output() public dragulaOnCancel: EventEmitter<any> = new EventEmitter<any>();
+  @Output() public dragulaOnRemove: EventEmitter<any> = new EventEmitter<any>();
+  @Output() public dragulaOnShadow: EventEmitter<any> = new EventEmitter<any>();
+  @Output() public dragulaOnOver: EventEmitter<any> = new EventEmitter<any>();
+  @Output() public dragulaOnOut: EventEmitter<any> = new EventEmitter<any>();
+  @Output() public dragulaOnCloned: EventEmitter<any> = new EventEmitter<any>();
+
   private container: any;
   private drake: any;
 
   private el: ElementRef;
   private dragulaService: DragulaService;
+
   public constructor(el: ElementRef, dragulaService: DragulaService) {
     this.el = el;
     this.dragulaService = dragulaService;
@@ -36,12 +48,42 @@ export class DragulaDirective implements OnInit, OnChanges {
       this.drake.containers.push(this.container);
     } else {
       this.drake = dragula([this.container], Object.assign({}, this.dragulaOptions));
+
+      this.drake.on('drop', (...args: any[]): void => {
+        this.dragulaOnDrop.emit(args);
+      });
+
+      this.drake.on('drag', (...args: any[]): void => {
+        this.dragulaOnDrag.emit(args);
+      });
+      this.drake.on('dragend', (...args: any[]): void => {
+        this.dragulaOnDragend.emit(args);
+      });
+      this.drake.on('cancel', (...args: any[]): void => {
+        this.dragulaOnCancel.emit(args);
+      });
+      this.drake.on('remove', (...args: any[]): void => {
+        this.dragulaOnRemove.emit(args);
+      });
+      this.drake.on('shadow', (...args: any[]): void => {
+        this.dragulaOnShadow.emit(args);
+      });
+      this.drake.on('over', (...args: any[]): void => {
+        this.dragulaOnOver.emit(args);
+      });
+      this.drake.on('out', (...args: any[]): void => {
+        this.dragulaOnOut.emit(args);
+      });
+      this.drake.on('cloned', (...args: any[]): void => {
+        this.dragulaOnCloned.emit(args);
+      });
+
       checkModel();
       this.dragulaService.add(this.dragula, this.drake);
     }
   }
 
-  public ngOnChanges(changes: {dragulaModel?: SimpleChange}): void {
+  public ngOnChanges(changes: { dragulaModel?: SimpleChange }): void {
     // console.log('dragula.directive: ngOnChanges');
     // console.log(changes);
     if (changes && changes.dragulaModel) {


### PR DESCRIPTION
With this change, you're able to use Angular style events like `(dragulaOnDrop)="onItemDropped($event)".` rather than using a service. All of Dragula's events are added and all arguments are passed as array (see [https://github.com/bevacqua/dragula](https://github.com/bevacqua/dragula)). Simply prefix the event with "dragulaOn" and capitalize the first letter. I would've typed everything but that hasn't been done for anything else so that felt kind of out of sync with the rest.