### PR TITLE
Update dragula.provider.ts

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ng2-dragula-base",
   "private": true,
-  "version": "1.3.1",
+  "version": "1.3.2",
   "main": "index.js",
   "typings": "index.d.ts",
   "description": "Simple drag and drop with dragula",

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "version": "npm run flow.changelog && git add -A"
   },
   "dependencies": {
-    "dragula": "https://github.com/Eshkol/dragula.git"
+    "dragula-mouse": "3.7.2"
   },
   "peerDependencies": {
     "@angular/core": "^2.3.1 || >=4.0.0",

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "version": "npm run flow.changelog && git add -A"
   },
   "dependencies": {
-    "dragula": "^3.7.2"
+    "dragula": "https://github.com/Eshkol/dragula.git"
   },
   "peerDependencies": {
     "@angular/core": "^2.3.1 || >=4.0.0",

--- a/src/components/dragula.provider.ts
+++ b/src/components/dragula.provider.ts
@@ -76,6 +76,8 @@ export class DragulaService {
       dragIndex = this.domIndexOf(el, source);
     });
     drake.on('drop', (dropElm: any, target: any, source: any) => {
+      if(drake.isCancel)
+        return;
       if (!drake.models || !target) {
         return;
       }


### PR DESCRIPTION
When tring to use drake cancel on drop event, dragula.service throws an error -  on statement "target.removeChild(dropElm)" , since target already removed the dropElm.

Suggested solution:
Add a new property 'drake.isCancel' , use it before calling cancel(), and check in the provider for this flag.