### PR TITLE
Line removes the dropped object

### DIFF
--- a/src/components/dragula.provider.ts
+++ b/src/components/dragula.provider.ts
@@ -94,7 +94,7 @@ export class DragulaService {
           sourceModel.splice(dragIndex, 1);
         }
         targetModel.splice(dropIndex, 0, dropElmModel);
-        target.removeChild(dropElm); // element must be removed for ngFor to apply correctly
+
       }
       this.dropModel.emit([name, dropElm, target, source]);
     });


### PR DESCRIPTION
This line removes the "dropped" object when working within a model.
The comment "element must be removed for ngFor to apply correctly" is not reproducible.

Eg. There are two containers - one for the group and one for the items.
Moving a Group works fine but when an item is moved from Group A to Group B, the item is not visible anymore in the view because it is removed.
The object level works fine.
 