### PR TITLE
Change DragulaModule to use ModuleWithProviders.

### DIFF
--- a/demo/src/app/app.module.ts
+++ b/demo/src/app/app.module.ts
@@ -15,7 +15,7 @@ import { DemoComponent } from './app.component';
   imports: [
     BrowserModule,
     FormsModule,
-    DragulaModule,
+    DragulaModule.forRoot(),
     CommonModule
   ],
   providers: [],

--- a/src/components/dragular.module.ts
+++ b/src/components/dragular.module.ts
@@ -1,11 +1,16 @@
-import { NgModule } from '@angular/core';
+import { NgModule, ModuleWithProviders } from '@angular/core';
 import { DragulaDirective } from './dragula.directive';
 import { DragulaService } from './dragula.provider';
 
 @NgModule({
   exports: [DragulaDirective],
-  declarations: [DragulaDirective],
-  providers: [DragulaService]
+  declarations: [DragulaDirective]
 })
 export class DragulaModule {
+  public static forRoot(): ModuleWithProviders {
+    return {
+      ngModule: DragulaModule,
+      providers: [DragulaService]
+    };
+  }
 }

--- a/src/spec/dragula.directive.spec.ts
+++ b/src/spec/dragula.directive.spec.ts
@@ -14,7 +14,7 @@ describe('Component: ng2-dragula', () => {
   beforeEach(() => {
     TestBed.configureTestingModule({
       declarations: [TestNGDragulaComponent],
-      imports: [DragulaModule]
+      imports: [DragulaModule.forRoot()]
     });
     TestBed.overrideComponent(TestNGDragulaComponent, {set: {template: html}});
     fixture = TestBed.createComponent(TestNGDragulaComponent);


### PR DESCRIPTION
This fixes the problem people have when trying to use Dragula across multiple components in different modules. Without this, importing the DragulaModule to gain access to the DragulaDirective sets up a new DragulaService every time. 

See #187 