### PR TITLE
Make the moves function more general purpose

### DIFF
--- a/demo/src/app/templates/much-example.html
+++ b/demo/src/app/templates/much-example.html
@@ -25,7 +25,7 @@ class MuchExample &#123;
   constructor(private dragulaService: DragulaService) &#123;
     dragulaService.setOptions('sixth-bag', &#123;
       moves: function (el, container, handle) &#123;
-        return handle.className === 'handle';
+        return typeof handle.className === 'string' && handle.className.split(' ').indexOf('handle') >= 0;
       }
     });
   }


### PR DESCRIPTION
In the wild className can be null, not a string or contain more than one class.