### PR TITLE
init dragulaModel with async value

### DIFF
--- a/src/components/dragula.directive.ts
+++ b/src/components/dragula.directive.ts
@@ -9,6 +9,7 @@ export class DragulaDirective implements OnInit, OnChanges {
   @Input() public dragulaOptions: any;
   private container: any;
   private drake: any;
+  private _dragulaModel: boolean;
 
   private el: ElementRef;
   private dragulaService: DragulaService;
@@ -22,7 +23,7 @@ export class DragulaDirective implements OnInit, OnChanges {
     // console.log(this.bag);
     let bag = this.dragulaService.find(this.dragula);
     let checkModel = () => {
-      if (this.dragulaModel) {
+      if (this._dragulaModel) {
         if (this.drake.models) {
           this.drake.models.push(this.dragulaModel);
         } else {
@@ -52,6 +53,8 @@ export class DragulaDirective implements OnInit, OnChanges {
         } else {
           this.drake.models = [changes.dragulaModel.currentValue];
         }
+      } else {
+        this._dragulaModel = true;
       }
     }
   }


### PR DESCRIPTION
I am using dragulaModel to sync data order with my model. I declare the model variable without an init value, then giving it the value from a result of promise in async NgOnInit. I found that my model cant sync with reordering action in page, so i do some changes with this.