### PR TITLE
don't crash angular when source model is not defined

### DIFF
--- a/modules/ng2-dragula/src/components/dragula.service.ts
+++ b/modules/ng2-dragula/src/components/dragula.service.ts
@@ -200,6 +200,7 @@ export class DragulaService {
         targetModel = sourceModel;
       } else {
         let isCopying = dragElm !== dropElm;
+        if (!sourceModel) return; 
         item = sourceModel[dragIndex];
         if (isCopying) {
           if (!options.copyItem) {


### PR DESCRIPTION
When I drag an item between to scroll lists a couple of times and drop it in between them, I get sourceModel is undefined. This workaround fixes the issue. Perhaps this stems from a bigger issue? 

