### PR TITLE
Fix for #912

### DIFF
--- a/modules/ng2-dragula/src/MockDrake.ts
+++ b/modules/ng2-dragula/src/MockDrake.ts
@@ -4,6 +4,7 @@ import { filter } from 'rxjs/operators';
 import { EventTypes } from './EventTypes';
 import { DragulaOptions } from './DragulaOptions';
 import { DrakeFactory } from './DrakeFactory';
+import { Drake } from 'dragula';
 
 export const MockDrakeFactory = new DrakeFactory((containers, options) => {
   return new MockDrake(containers, options);
@@ -65,7 +66,7 @@ export class MockDrake implements DrakeWithModels {
 
   private subs = new Subscription();
 
-  on(event: string, callback: Function): void {
+  on(event: string, callback: Function): Drake {
     this.subs.add(this.emitter$
       .pipe(
         filter(({ eventType }) => eventType === event)


### PR DESCRIPTION
Fix
```
Class 'MockDrake' incorrectly implements interface 'DrakeWithModels'. Types of property 'on' are
            incompatible. Type '(event: string, callback: Function) => void' is not assignable to type '(events: string,
            callback: Function) => Drake'. Type 'void' is not assignable to type 'Drake'.
```

**Relevant issues**

https://github.com/valor-software/ng2-dragula/issues/912
https://github.com/valor-software/ng2-dragula/issues/913

**Before submitting**

If your pull request includes changes to the library code:

- [ ] Add tests (in `modules/ng2-dragula/src/spec/...`) for any code you have changed
- [ ] Make sure the test suite passes
- [ ] Make sure the demo app isn't broken

