### PR TITLE
Check if group exists before destructuring it.

### DIFF
--- a/modules/ng2-dragula/src/components/dragula.directive.ts
+++ b/modules/ng2-dragula/src/components/dragula.directive.ts
@@ -41,8 +41,9 @@ export class DragulaDirective implements OnChanges, OnDestroy {
       // because if you're changing the group name, you'll be doing setup or teardown
       // it also only runs if there is a group name to attach to.
       const { previousValue: prev, currentValue: current, firstChange } = changes.dragulaModel;
-      const { drake } = this.group;
-      if (this.dragula && drake) {
+      if (this.dragula && this.group) {
+        const { drake } = this.group;
+
         drake.models = drake.models || [];
         let prevIndex = drake.models.indexOf(prev);
         if (prevIndex !== -1) {


### PR DESCRIPTION
I am getting the following error: 

```
ERROR TypeError: Cannot destructure property `drake` of 'undefined' or 'null'.
    at DragulaDirective.ngOnChanges (ng2-dragula.js:319)
    at checkAndUpdateDirectiveInline (core.js:26272)
    at checkAndUpdateNodeInline (core.js:37133)
    at checkAndUpdateNode (core.js:37072)
    at debugCheckAndUpdateNode (core.js:38094)
    at debugCheckDirectivesFn (core.js:38037)
    at Object.updateDirectives (container.component.html:4)
    at Object.debugUpdateDirectives [as updateDirectives] (core.js:38025)
    at checkAndUpdateView (core.js:37037)
    at callViewAction (core.js:37403)
```

Because of attemping destructuring of `group`, which is temporarily undefined. 

As this is such a minor change, I didn't set up tests and such. If needed, I can take the time to set up the project and run the tests.